### PR TITLE
Fix dark mode styling

### DIFF
--- a/birthday_bag_exporter.py
+++ b/birthday_bag_exporter.py
@@ -72,6 +72,9 @@ class BirthdayBagExporter:
         
         # Theme settings
         self.dark_mode = tk.BooleanVar(value=False)
+        # Use a style that allows color customization
+        self.style = ttk.Style()
+        self.style.theme_use("clam")
         self.apply_theme()
         
         # Route assignments dictionary - easily editable
@@ -181,7 +184,9 @@ class BirthdayBagExporter:
     
     def apply_theme(self):
         """Apply light or dark theme based on current setting"""
-        style = ttk.Style()
+        style = self.style
+        # Ensure the theme supports color customization
+        style.theme_use("clam")
         
         if self.dark_mode.get():
             # Dark mode


### PR DESCRIPTION
## Summary
- ensure Tkinter uses a theme that respects custom colors
- centralize style object and re-use when toggling themes

## Testing
- `python -m py_compile birthday_bag_exporter.py`
- `pip install -r requirements.txt`
- `python birthday_bag_exporter.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_688196a4adac832397c2e5b024a67437